### PR TITLE
add: set timeout_second and move limit_size to config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,6 @@ The location of the file depends on your OS:
 
 Sample config.toml file is `examples/key_bind.ron`:
 
-### table config
-
-The location of the file depends on your OS:
-
-- macOS: `$HOME/.config/zhobo/table_config.toml`
-- Linux: `$HOME/.config/zhobo/table_config.toml`
-- Windows: `%APPDATA%/zhobo/tabel_config.toml`
-
-```bash
-limit_size = 200
-```
-
 ## contribution
 
 Contributions are welcome.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -3,6 +3,8 @@ type = "mysql"
 user = "root"
 host = "localhost"
 port = 3306
+limit_size = 400
+timeout_second = 5
 
 [[conn]]
 type = "mysql"

--- a/examples/table_config.toml
+++ b/examples/table_config.toml
@@ -1,1 +1,0 @@
-limit_size = 400

--- a/src/app.rs
+++ b/src/app.rs
@@ -146,7 +146,8 @@ impl App {
                 Some(Box::new(
                     MySqlPool::new(
                         conn.database_url()?.as_str(),
-                        self.config.table_config.limit_size,
+                        conn.limit_size,
+                        conn.timeout_second,
                     )
                     .await?,
                 ))
@@ -154,7 +155,8 @@ impl App {
                 Some(Box::new(
                     PostgresPool::new(
                         conn.database_url()?.as_str(),
-                        self.config.table_config.limit_size,
+                        conn.limit_size,
+                        conn.timeout_second,
                     )
                     .await?,
                 ))
@@ -162,7 +164,8 @@ impl App {
                 Some(Box::new(
                     SqlitePool::new(
                         conn.database_url()?.as_str(),
-                        self.config.table_config.limit_size,
+                        conn.limit_size,
+                        conn.timeout_second,
                     )
                     .await?,
                 ))
@@ -333,7 +336,13 @@ impl App {
                         }
 
                         if let Some(index) = self.record_table.table.selected_row.selected() {
-                            if index.saturating_add(1) % self.config.table_config.limit_size == 0
+                            let limit_size =
+                                if let Some(connection) = self.connections.selected_connection() {
+                                    connection.limit_size
+                                } else {
+                                    200
+                                };
+                            if index.saturating_add(1) % limit_size == 0
                                 && index >= self.record_table.table.rows.len() - 1
                             {
                                 if let Some((database, table)) =

--- a/src/config.rs
+++ b/src/config.rs
@@ -609,6 +609,8 @@ mod test {
             password: Some("password".to_owned()),
             database: Some("city".to_owned()),
             unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
         };
 
         assert_eq!(
@@ -632,6 +634,8 @@ mod test {
             password: Some("password".to_owned()),
             database: Some("city".to_owned()),
             unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
         };
 
         assert_eq!(
@@ -654,6 +658,8 @@ mod test {
             password: None,
             database: None,
             unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
         };
 
         let sqlite_result = sqlite_conn.database_url().unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,10 +20,6 @@ pub struct CliConfig {
     /// Set the key bind file
     #[structopt(long, short, global = true)]
     key_bind_path: Option<std::path::PathBuf>,
-
-    /// Set the table viewer config
-    #[structopt(long, short, global = true)]
-    table_config_path: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -40,8 +36,6 @@ pub struct Config {
     pub key_config: KeyConfig,
     #[serde(default)]
     pub log_level: LogLevel,
-    #[serde(default)]
-    pub table_config: TableConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -77,10 +71,11 @@ impl Default for Config {
                 password: None,
                 database: None,
                 unix_domain_socket: None,
+                limit_size: 200,
+                timeout_second: 5,
             }],
             key_config: KeyConfig::default(),
             log_level: LogLevel::default(),
-            table_config: TableConfig::default(),
         }
     }
 }
@@ -96,18 +91,18 @@ pub struct Connection {
     password: Option<String>,
     unix_domain_socket: Option<std::path::PathBuf>,
     pub database: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[cfg_attr(test, derive(Serialize, PartialEq))]
-pub struct TableConfig {
+    #[serde(default = "default_limit_size")]
     pub limit_size: usize,
+    #[serde(default = "default_timeout_second")]
+    pub timeout_second: u64,
 }
 
-impl Default for TableConfig {
-    fn default() -> Self {
-        Self { limit_size: 200 }
-    }
+fn default_limit_size() -> usize {
+    200
+}
+
+fn default_timeout_second() -> u64 {
+    5
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -214,51 +209,26 @@ impl Config {
             get_app_config_path()?.join("key_bind.ron")
         };
 
-        let table_config_path = if let Some(table_config_path) = &config.table_config_path {
-            table_config_path.clone()
-        } else {
-            get_app_config_path()?.join("table_config.toml")
-        };
-
-        let table_config = Config::_load_table_config(table_config_path)?;
         if let Ok(file) = File::open(config_path) {
             let mut buf_reader = BufReader::new(file);
             let mut contents = String::new();
             buf_reader.read_to_string(&mut contents)?;
             let config: Result<ReadConfig, toml::de::Error> = toml::from_str(&contents);
             match config {
-                Ok(config) => return Ok(Config::build(config, key_bind_path, table_config)),
+                Ok(config) => return Ok(Config::build(config, key_bind_path)),
                 Err(e) => panic!("fail to parse connection config file: {}", e),
             }
         }
 
-        Ok(Config {
-            table_config,
-            ..Default::default()
-        })
+        Ok(Config::default())
     }
 
-    fn _load_table_config(table_config_path: PathBuf) -> anyhow::Result<TableConfig> {
-        if let Ok(file) = File::open(table_config_path) {
-            let mut buf_reader = BufReader::new(file);
-            let mut contents = String::new();
-            buf_reader.read_to_string(&mut contents)?;
-            let table_config: Result<TableConfig, toml::de::Error> = toml::from_str(&contents);
-            match table_config {
-                Ok(config) => return Ok(config),
-                Err(e) => panic!("fail to parse table config: {}", e),
-            }
-        }
-        Ok(TableConfig::default())
-    }
-
-    fn build(read_config: ReadConfig, key_bind_path: PathBuf, table_config: TableConfig) -> Self {
+    fn build(read_config: ReadConfig, key_bind_path: PathBuf) -> Self {
         let key_bind = KeyBind::load(key_bind_path).unwrap();
         Config {
             conn: read_config.conn,
             log_level: read_config.log_level,
             key_config: KeyConfig::from(key_bind),
-            table_config,
         }
     }
 }
@@ -470,7 +440,6 @@ mod test {
         let cli_config = CliConfig {
             config_path: Some(Path::new("examples/config.toml").to_path_buf()),
             key_bind_path: Some(Path::new("examples/key_bind.ron").to_path_buf()),
-            table_config_path: Some(Path::new("examples/table_config.toml").to_path_buf()),
         };
 
         assert_eq!(Config::new(&cli_config).is_ok(), true);
@@ -489,6 +458,8 @@ mod test {
             password: Some("password".to_owned()),
             database: Some("city".to_owned()),
             unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
         };
 
         let mysql_result = mysql_conn.database_url().unwrap();
@@ -507,6 +478,8 @@ mod test {
             password: Some("password".to_owned()),
             database: Some("city".to_owned()),
             unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
         };
 
         let postgres_result = postgres_conn.database_url().unwrap();
@@ -525,6 +498,8 @@ mod test {
             password: None,
             database: None,
             unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
         };
 
         let sqlite_result = sqlite_conn.database_url().unwrap();
@@ -564,6 +539,8 @@ mod test {
             password: Some("password".to_owned()),
             database: Some("city".to_owned()),
             unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
         };
 
         assert_eq!(
@@ -587,6 +564,8 @@ mod test {
             password: Some("password".to_owned()),
             database: Some("city".to_owned()),
             unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
         };
 
         assert_eq!(
@@ -609,6 +588,8 @@ mod test {
             password: None,
             database: None,
             unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
         };
 
         let sqlite_result = sqlite_conn.database_url().unwrap();

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -15,10 +15,14 @@ pub struct MySqlPool {
 }
 
 impl MySqlPool {
-    pub async fn new(database_url: &str, limit_size: usize) -> anyhow::Result<Self> {
+    pub async fn new(
+        database_url: &str,
+        limit_size: usize,
+        timeout_second: u64,
+    ) -> anyhow::Result<Self> {
         Ok(Self {
             pool: MySqlPoolOptions::new()
-                .acquire_timeout(Duration::from_secs(5))
+                .acquire_timeout(Duration::from_secs(timeout_second))
                 .connect(database_url)
                 .await?,
             limit_size,

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -16,10 +16,14 @@ pub struct PostgresPool {
 }
 
 impl PostgresPool {
-    pub async fn new(database_url: &str, limit_size: usize) -> anyhow::Result<Self> {
+    pub async fn new(
+        database_url: &str,
+        limit_size: usize,
+        timeout_second: u64,
+    ) -> anyhow::Result<Self> {
         Ok(Self {
             pool: PgPoolOptions::new()
-                .acquire_timeout(Duration::from_secs(5))
+                .acquire_timeout(Duration::from_secs(timeout_second))
                 .connect(database_url)
                 .await?,
             limit_size,

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -15,10 +15,14 @@ pub struct SqlitePool {
 }
 
 impl SqlitePool {
-    pub async fn new(database_url: &str, limit_size: usize) -> anyhow::Result<Self> {
+    pub async fn new(
+        database_url: &str,
+        limit_size: usize,
+        timeout_second: u64,
+    ) -> anyhow::Result<Self> {
         Ok(Self {
             pool: SqlitePoolOptions::new()
-                .acquire_timeout(Duration::from_secs(5))
+                .acquire_timeout(Duration::from_secs(timeout_second))
                 .connect(database_url)
                 .await?,
             limit_size,


### PR DESCRIPTION
Here's a checklist for things that will be checked during review or continuous integration.

- [x] Added passing unit tests
- [x] `cargo test` passes locally. It takes much time.
- [x] Run `cargo fmt`
 
---

changelog:
we can set a timeout_second per connections now.
and move limit_size in config.toml

close #44 