### PR TITLE
use sql from sqlite_master for checking table definition

### DIFF
--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -421,10 +421,11 @@ impl Pool for SqlitePool {
         Ok(foreign_keys)
     }
 
-    async fn get_definition(&self, database: &Database, table: &Table) -> anyhow::Result<String> {
-        let query = format!("SHOW CREATE TABLE `{}`.`{}`;", database.name, table.name);
-        let row = sqlx::query(query.as_str()).fetch_one(&self.pool).await?;
-        Ok(row.get::<String, usize>(1))
+    async fn get_definition(&self, _database: &Database, table: &Table) -> anyhow::Result<String> {
+        let query = sqlx::query("SELECT sql FROM sqlite_master WHERE type='table' AND name=?;")
+            .bind(&table.name);
+        let row = query.fetch_one(&self.pool).await?;
+        Ok(row.get::<String, usize>(0))
     }
     async fn close(&self) {
         self.pool.close().await;


### PR DESCRIPTION
Here's a checklist for things that will be checked during review or continuous integration.

- [x] Added passing unit tests
- [x] `cargo test` passes locally. It takes much time.
- [x] Run `cargo fmt`
 
---

changelog:
fix the table definition query in sqlite3.
close #86 
