### PR TITLE
Refactor connection

### DIFF
--- a/src/components/connections.rs
+++ b/src/components/connections.rs
@@ -1,6 +1,7 @@
 use super::{Component, EventState, StatefulDrawableComponent};
 use crate::components::command::CommandInfo;
-use crate::config::{Connection, KeyConfig};
+use crate::config::KeyConfig;
+use crate::connection::Connection;
 use crate::event::Key;
 use anyhow::Result;
 use ratatui::{

--- a/src/components/databases.rs
+++ b/src/components/databases.rs
@@ -3,7 +3,8 @@ use super::{
     EventState,
 };
 use crate::components::command::{self, CommandInfo};
-use crate::config::{Connection, KeyConfig};
+use crate::config::KeyConfig;
+use crate::connection::Connection;
 use crate::database::Pool;
 use crate::event::Key;
 use crate::tree::{Database, DatabaseTree, DatabaseTreeItem};

--- a/src/components/databases.rs
+++ b/src/components/databases.rs
@@ -55,7 +55,7 @@ impl DatabasesComponent {
     }
 
     pub async fn update(&mut self, connection: &Connection, pool: &Box<dyn Pool>) -> Result<()> {
-        let databases = match &connection.database {
+        let databases = match connection.get_database() {
             Some(database) => vec![Database::new(
                 database.clone(),
                 pool.get_tables(database.clone()).await?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,11 @@
+use crate::connection::Connection;
 use crate::key_bind::KeyBind;
 use crate::log::LogLevel;
 use crate::Key;
 use serde::Deserialize;
-use std::fmt;
 use std::fs::File;
 use std::io::{BufReader, Read};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[cfg(test)]
@@ -38,71 +38,14 @@ pub struct Config {
     pub log_level: LogLevel,
 }
 
-#[derive(Debug, Deserialize, Clone)]
-enum DatabaseType {
-    #[serde(rename = "mysql")]
-    MySql,
-    #[serde(rename = "postgres")]
-    Postgres,
-    #[serde(rename = "sqlite")]
-    Sqlite,
-}
-
-impl fmt::Display for DatabaseType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::MySql => write!(f, "mysql"),
-            Self::Postgres => write!(f, "postgres"),
-            Self::Sqlite => write!(f, "sqlite"),
-        }
-    }
-}
-
 impl Default for Config {
     fn default() -> Self {
         Self {
-            conn: vec![Connection {
-                r#type: DatabaseType::MySql,
-                name: None,
-                user: Some("root".to_string()),
-                host: Some("localhost".to_string()),
-                port: Some(3306),
-                path: None,
-                password: None,
-                database: None,
-                unix_domain_socket: None,
-                limit_size: 200,
-                timeout_second: 5,
-            }],
+            conn: vec![Connection::default()],
             key_config: KeyConfig::default(),
             log_level: LogLevel::default(),
         }
     }
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct Connection {
-    r#type: DatabaseType,
-    name: Option<String>,
-    user: Option<String>,
-    host: Option<String>,
-    port: Option<u64>,
-    path: Option<std::path::PathBuf>,
-    password: Option<String>,
-    unix_domain_socket: Option<std::path::PathBuf>,
-    pub database: Option<String>,
-    #[serde(default = "default_limit_size")]
-    pub limit_size: usize,
-    #[serde(default = "default_timeout_second")]
-    pub timeout_second: u64,
-}
-
-fn default_limit_size() -> usize {
-    200
-}
-
-fn default_timeout_second() -> u64 {
-    5
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -233,176 +176,6 @@ impl Config {
     }
 }
 
-impl Connection {
-    pub fn database_url(&self) -> anyhow::Result<String> {
-        let password = self
-            .password
-            .as_ref()
-            .map_or(String::new(), |p| p.to_string());
-        self.build_database_url(password)
-    }
-
-    fn masked_database_url(&self) -> anyhow::Result<String> {
-        let password = self
-            .password
-            .as_ref()
-            .map_or(String::new(), |p| p.to_string());
-
-        let masked_password = "*".repeat(password.len());
-        self.build_database_url(masked_password)
-    }
-
-    fn build_database_url(&self, password: String) -> anyhow::Result<String> {
-        match self.r#type {
-            DatabaseType::MySql => {
-                let user = self.user.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type mysql needs the user field in Connection::build_database_url"
-                    )
-                })?;
-                let host = self.host.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type mysql needs the host field in Connection::build_database_url"
-                    )
-                })?;
-                let port = self.port.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type mysql needs the port field in Connection::build_database_url"
-                    )
-                })?;
-                let unix_domain_socket = self
-                    .valid_unix_domain_socket()
-                    .map_or(String::new(), |uds| format!("?socket={}", uds));
-
-                match self.database.as_ref() {
-                    Some(database) => Ok(format!(
-                        "mysql://{user}:{password}@{host}:{port}/{database}{unix_domain_socket}",
-                        user = user,
-                        password = password,
-                        host = host,
-                        port = port,
-                        database = database,
-                        unix_domain_socket = unix_domain_socket
-                    )),
-                    None => Ok(format!(
-                        "mysql://{user}:{password}@{host}:{port}{unix_domain_socket}",
-                        user = user,
-                        password = password,
-                        host = host,
-                        port = port,
-                        unix_domain_socket = unix_domain_socket
-                    )),
-                }
-            }
-            DatabaseType::Postgres => {
-                let user = self.user.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type postgres needs the user field in Connection::build_database_url"
-                    )
-                })?;
-                let host = self.host.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type postgres needs the host field in Connection::build_database_url"
-                    )
-                })?;
-                let port = self.port.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type postgres needs the port field in Connection::build_database_url"
-                    )
-                })?;
-
-                if let Some(unix_domain_socket) = self.valid_unix_domain_socket() {
-                    match self.database.as_ref() {
-                        Some(database) => Ok(format!(
-                            "postgres://?dbname={database}&host={unix_domain_socket}&user={user}&password={password}",
-                            database = database,
-                            unix_domain_socket = unix_domain_socket,
-                            user = user,
-                            password = password,
-                        )),
-                        None => Ok(format!(
-                            "postgres://?host={unix_domain_socket}&user={user}&password={password}",
-                            unix_domain_socket = unix_domain_socket,
-                            user = user,
-                            password = password,
-                        )),
-                    }
-                } else {
-                    match self.database.as_ref() {
-                        Some(database) => Ok(format!(
-                            "postgres://{user}:{password}@{host}:{port}/{database}",
-                            user = user,
-                            password = password,
-                            host = host,
-                            port = port,
-                            database = database,
-                        )),
-                        None => Ok(format!(
-                            "postgres://{user}:{password}@{host}:{port}",
-                            user = user,
-                            password = password,
-                            host = host,
-                            port = port,
-                        )),
-                    }
-                }
-            }
-            DatabaseType::Sqlite => {
-                let path = self.path.as_ref().map_or(
-                    Err(anyhow::anyhow!(
-                        "type sqlite needs the path field in Connection::build_database_url"
-                    )),
-                    |path| {
-                        expand_path(path).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "cannot expand file path in Connection::build_database_url"
-                            )
-                        })
-                    },
-                )?;
-
-                Ok(format!("sqlite://{path}", path = path.to_str().unwrap()))
-            }
-        }
-    }
-
-    pub fn database_url_with_name(&self) -> anyhow::Result<String> {
-        match self.masked_database_url() {
-            Ok(url) => Ok(match &self.name {
-                Some(name) => format!("[{name}] {database_url}", name = name, database_url = url),
-                None => url,
-            }),
-            Err(e) => Err(anyhow::anyhow!(e)
-                .context("Failed to masked_database_url in Connection::database_url_with_name")),
-        }
-    }
-
-    pub fn is_mysql(&self) -> bool {
-        matches!(self.r#type, DatabaseType::MySql)
-    }
-
-    pub fn is_postgres(&self) -> bool {
-        matches!(self.r#type, DatabaseType::Postgres)
-    }
-
-    fn valid_unix_domain_socket(&self) -> Option<String> {
-        if cfg!(windows) {
-            // NOTE:
-            // windows also supports UDS, but `rust` does not support UDS in windows now.
-            // https://github.com/rust-lang/rust/issues/56533
-            return None;
-        }
-        return self.unix_domain_socket.as_ref().and_then(|uds| {
-            let path = expand_path(uds)?;
-            let path_str = path.to_str()?;
-            if path_str.is_empty() {
-                return None;
-            }
-            Some(path_str.to_owned())
-        });
-    }
-}
-
 pub fn get_app_config_path() -> anyhow::Result<std::path::PathBuf> {
     let mut path = if cfg!(target_os = "macos") {
         dirs_next::home_dir().map(|h| h.join(".config"))
@@ -416,34 +189,12 @@ pub fn get_app_config_path() -> anyhow::Result<std::path::PathBuf> {
     Ok(path)
 }
 
-fn expand_path(path: &Path) -> Option<PathBuf> {
-    let mut expanded_path = PathBuf::new();
-    let mut path_iter = path.iter();
-    if path.starts_with("~") {
-        path_iter.next()?;
-        expanded_path = expanded_path.join(dirs_next::home_dir()?);
-    }
-    for path in path_iter {
-        let path = path.to_str()?;
-        expanded_path = if cfg!(unix) && path.starts_with('$') {
-            expanded_path.join(std::env::var(path.strip_prefix('$')?).unwrap_or_default())
-        } else if cfg!(windows) && path.starts_with('%') && path.ends_with('%') {
-            expanded_path
-                .join(std::env::var(path.strip_prefix('%')?.strip_suffix('%')?).unwrap_or_default())
-        } else {
-            expanded_path.join(path)
-        }
-    }
-    Some(expanded_path)
-}
-
 #[cfg(test)]
 mod test {
-    use super::{
-        expand_path, CliConfig, Config, Connection, DatabaseType, KeyConfig, Path, PathBuf,
-    };
+    use std::path::Path;
+
+    use super::{CliConfig, Config, KeyConfig};
     use serde_json::Value;
-    use std::env;
 
     #[test]
     fn test_load_config() {
@@ -453,67 +204,6 @@ mod test {
         };
 
         assert_eq!(Config::new(&cli_config).is_ok(), true);
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_database_url() {
-        let mysql_conn = Connection {
-            r#type: DatabaseType::MySql,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
-
-        let mysql_result = mysql_conn.database_url().unwrap();
-        assert_eq!(
-            mysql_result,
-            "mysql://root:password@localhost:3306/city".to_owned()
-        );
-
-        let postgres_conn = Connection {
-            r#type: DatabaseType::Postgres,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
-
-        let postgres_result = postgres_conn.database_url().unwrap();
-        assert_eq!(
-            postgres_result,
-            "postgres://root:password@localhost:3306/city".to_owned()
-        );
-
-        let sqlite_conn = Connection {
-            r#type: DatabaseType::Sqlite,
-            name: None,
-            user: None,
-            host: None,
-            port: None,
-            path: Some(PathBuf::from("/home/user/sqlite3.db")),
-            password: None,
-            database: None,
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
-
-        let sqlite_result = sqlite_conn.database_url().unwrap();
-        assert_eq!(sqlite_result, "sqlite:///home/user/sqlite3.db".to_owned());
     }
 
     #[test]
@@ -534,209 +224,5 @@ mod test {
             values.dedup();
             pretty_assertions::assert_eq!(before_values, values);
         }
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_dataset_url_in_unix() {
-        let mut mysql_conn = Connection {
-            r#type: DatabaseType::MySql,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
-
-        assert_eq!(
-            mysql_conn.database_url().unwrap(),
-            "mysql://root:password@localhost:3306/city".to_owned()
-        );
-
-        mysql_conn.unix_domain_socket = Some(Path::new("/tmp/mysql.sock").to_path_buf());
-        assert_eq!(
-            mysql_conn.database_url().unwrap(),
-            "mysql://root:password@localhost:3306/city?socket=/tmp/mysql.sock".to_owned()
-        );
-
-        let mut postgres_conn = Connection {
-            r#type: DatabaseType::Postgres,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
-
-        assert_eq!(
-            postgres_conn.database_url().unwrap(),
-            "postgres://root:password@localhost:3306/city".to_owned()
-        );
-        postgres_conn.unix_domain_socket = Some(Path::new("/tmp").to_path_buf());
-        assert_eq!(
-            postgres_conn.database_url().unwrap(),
-            "postgres://?dbname=city&host=/tmp&user=root&password=password".to_owned()
-        );
-
-        let sqlite_conn = Connection {
-            r#type: DatabaseType::Sqlite,
-            name: None,
-            user: None,
-            host: None,
-            port: None,
-            path: Some(PathBuf::from("/home/user/sqlite3.db")),
-            password: None,
-            database: None,
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
-
-        let sqlite_result = sqlite_conn.database_url().unwrap();
-        assert_eq!(sqlite_result, "sqlite:///home/user/sqlite3.db".to_owned());
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_database_url_in_windows() {
-        let mut mysql_conn = Connection {
-            r#type: DatabaseType::MySql,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
-
-        assert_eq!(
-            mysql_conn.database_url().unwrap(),
-            "mysql://root:password@localhost:3306/city".to_owned()
-        );
-
-        mysql_conn.unix_domain_socket = Some(Path::new("/tmp/mysql.sock").to_path_buf());
-        assert_eq!(
-            mysql_conn.database_url().unwrap(),
-            "mysql://root:password@localhost:3306/city".to_owned()
-        );
-
-        let mut postgres_conn = Connection {
-            r#type: DatabaseType::Postgres,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
-
-        assert_eq!(
-            postgres_conn.database_url().unwrap(),
-            "postgres://root:password@localhost:3306/city".to_owned()
-        );
-        postgres_conn.unix_domain_socket = Some(Path::new("/tmp").to_path_buf());
-        assert_eq!(
-            postgres_conn.database_url().unwrap(),
-            "postgres://root:password@localhost:3306/city".to_owned()
-        );
-
-        let sqlite_conn = Connection {
-            r#type: DatabaseType::Sqlite,
-            name: None,
-            user: None,
-            host: None,
-            port: None,
-            path: Some(PathBuf::from("/home/user/sqlite3.db")),
-            password: None,
-            database: None,
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
-
-        let sqlite_result = sqlite_conn.database_url().unwrap();
-        assert_eq!(
-            sqlite_result,
-            "sqlite://\\home\\user\\sqlite3.db".to_owned()
-        );
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_expand_path() {
-        let home = env::var("HOME").unwrap();
-        let test_env = "baz";
-        env::set_var("TEST", test_env);
-
-        assert_eq!(
-            expand_path(&Path::new("$HOME/foo")),
-            Some(PathBuf::from(&home).join("foo"))
-        );
-
-        assert_eq!(
-            expand_path(&Path::new("$HOME/foo/$TEST/bar")),
-            Some(PathBuf::from(&home).join("foo").join(test_env).join("bar"))
-        );
-
-        assert_eq!(
-            expand_path(&Path::new("~/foo")),
-            Some(PathBuf::from(&home).join("foo"))
-        );
-
-        assert_eq!(
-            expand_path(&Path::new("~/foo/~/bar")),
-            Some(PathBuf::from(&home).join("foo").join("~").join("bar"))
-        );
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_expand_patha() {
-        let home = std::env::var("HOMEPATH").unwrap();
-        let test_env = "baz";
-        env::set_var("TEST", test_env);
-
-        assert_eq!(
-            expand_path(&Path::new("%HOMEPATH%/foo")),
-            Some(PathBuf::from(&home).join("foo"))
-        );
-
-        assert_eq!(
-            expand_path(&Path::new("%HOMEPATH%/foo/%TEST%/bar")),
-            Some(PathBuf::from(&home).join("foo").join(test_env).join("bar"))
-        );
-
-        assert_eq!(
-            expand_path(&Path::new("~/foo")),
-            Some(PathBuf::from(&dirs_next::home_dir().unwrap()).join("foo"))
-        );
-
-        assert_eq!(
-            expand_path(&Path::new("~/foo/~/bar")),
-            Some(
-                PathBuf::from(&dirs_next::home_dir().unwrap())
-                    .join("foo")
-                    .join("~")
-                    .join("bar")
-            )
-        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::connection::Connection;
+use crate::connection::{Connection, ReadConnection};
 use crate::key_bind::KeyBind;
 use crate::log::LogLevel;
 use crate::Key;
@@ -24,17 +24,15 @@ pub struct CliConfig {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ReadConfig {
-    pub conn: Vec<Connection>,
+    pub conn: Vec<ReadConnection>,
     #[serde(default)]
     pub log_level: LogLevel,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct Config {
     pub conn: Vec<Connection>,
-    #[serde(default)]
     pub key_config: KeyConfig,
-    #[serde(default)]
     pub log_level: LogLevel,
 }
 
@@ -169,7 +167,11 @@ impl Config {
     fn build(read_config: ReadConfig, key_bind_path: PathBuf) -> Self {
         let key_bind = KeyBind::load(key_bind_path).unwrap();
         Config {
-            conn: read_config.conn,
+            conn: read_config
+                .conn
+                .into_iter()
+                .map(|c| Connection::from(c))
+                .collect::<Vec<Connection>>(),
             log_level: read_config.log_level,
             key_config: KeyConfig::from(key_bind),
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -26,15 +26,15 @@ impl fmt::Display for DatabaseType {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-pub struct Connection {
+pub struct ReadConnection {
     r#type: DatabaseType,
     name: Option<String>,
     user: Option<String>,
     host: Option<String>,
     port: Option<u64>,
-    path: Option<std::path::PathBuf>,
+    path: Option<PathBuf>,
     password: Option<String>,
-    unix_domain_socket: Option<std::path::PathBuf>,
+    unix_domain_socket: Option<PathBuf>,
     pub database: Option<String>,
     #[serde(default = "default_limit_size")]
     pub limit_size: usize,
@@ -42,7 +42,121 @@ pub struct Connection {
     pub timeout_second: u64,
 }
 
+#[derive(Debug, Clone)]
+pub enum Connection {
+    MySql(MySqlConnection),
+    Postgres(PostgresConnection),
+    Sqlite(SqliteConnection),
+}
+
 impl Connection {
+    pub fn from(read_connection: ReadConnection) -> Self {
+        match read_connection.r#type {
+            DatabaseType::MySql => Connection::MySql(MySqlConnection {
+                name: read_connection.name,
+                user: read_connection
+                    .user
+                    .expect("user must be specified for MySQL"),
+                password: read_connection.password,
+                host: read_connection
+                    .host
+                    .expect("host must be specified for MySQL"),
+                port: read_connection
+                    .port
+                    .expect("port must be specified for MySQL"),
+                database: read_connection.database,
+                unix_domain_socket: read_connection.unix_domain_socket,
+                limit_size: read_connection.limit_size,
+                timeout_second: read_connection.timeout_second,
+            }),
+            DatabaseType::Postgres => Connection::Postgres(PostgresConnection {
+                name: read_connection.name,
+                user: read_connection
+                    .user
+                    .expect("user must be specified for Postgres"),
+                password: read_connection.password,
+                host: read_connection
+                    .host
+                    .expect("host must be specified for Postgres"),
+                port: read_connection
+                    .port
+                    .expect("port must be specified for Postgres"),
+                database: read_connection.database,
+                unix_domain_socket: read_connection.unix_domain_socket,
+                limit_size: read_connection.limit_size,
+                timeout_second: read_connection.timeout_second,
+            }),
+            DatabaseType::Sqlite => Connection::Sqlite(SqliteConnection {
+                name: read_connection.name,
+                path: read_connection
+                    .path
+                    .expect("path must be specified for Sqlite"),
+                limit_size: read_connection.limit_size,
+                timeout_second: read_connection.timeout_second,
+            }),
+        }
+    }
+
+    pub fn get_database(&self) -> Option<String> {
+        match self {
+            Connection::MySql(conn) => conn.database.clone(),
+            Connection::Postgres(conn) => conn.database.clone(),
+            Connection::Sqlite(conn) => conn.path.to_str().map(|s| s.to_string()),
+        }
+    }
+
+    pub fn database_url(&self) -> anyhow::Result<String> {
+        match self {
+            Connection::MySql(conn) => conn.database_url(),
+            Connection::Postgres(conn) => conn.database_url(),
+            Connection::Sqlite(conn) => conn.database_url(),
+        }
+    }
+
+    pub fn database_url_with_name(&self) -> anyhow::Result<String> {
+        fn add_name_to_url(
+            url: anyhow::Result<String>,
+            name: Option<&String>,
+        ) -> anyhow::Result<String> {
+            match url {
+                Ok(url) => Ok(match name {
+                    Some(name) => {
+                        format!("[{name}] {database_url}", name = name, database_url = url)
+                    }
+                    None => url,
+                }),
+                Err(e) => Err(anyhow::anyhow!(e).context(
+                    "Failed to database_url_with_name in Connection::database_url_with_name",
+                )),
+            }
+        }
+
+        match self {
+            Connection::MySql(conn) => {
+                add_name_to_url(conn.database_url_with_masked_password(), conn.name.as_ref())
+            }
+            Connection::Postgres(conn) => {
+                add_name_to_url(conn.database_url_with_masked_password(), conn.name.as_ref())
+            }
+            Connection::Sqlite(conn) => add_name_to_url(conn.database_url(), conn.name.as_ref()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MySqlConnection {
+    name: Option<String>,
+    user: String,
+    password: Option<String>,
+    host: String,
+    port: u64,
+    pub database: Option<String>,
+    unix_domain_socket: Option<PathBuf>,
+    pub limit_size: usize,
+    pub timeout_second: u64,
+}
+
+impl MySqlConnection {
     pub fn database_url(&self) -> anyhow::Result<String> {
         let password = self
             .password
@@ -51,7 +165,7 @@ impl Connection {
         self.build_database_url(password)
     }
 
-    fn masked_database_url(&self) -> anyhow::Result<String> {
+    pub fn database_url_with_masked_password(&self) -> anyhow::Result<String> {
         let password = self
             .password
             .as_ref()
@@ -62,175 +176,160 @@ impl Connection {
     }
 
     fn build_database_url(&self, password: String) -> anyhow::Result<String> {
-        match self.r#type {
-            DatabaseType::MySql => {
-                let user = self.user.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type mysql needs the user field in Connection::build_database_url"
-                    )
-                })?;
-                let host = self.host.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type mysql needs the host field in Connection::build_database_url"
-                    )
-                })?;
-                let port = self.port.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type mysql needs the port field in Connection::build_database_url"
-                    )
-                })?;
-                let unix_domain_socket = self
-                    .valid_unix_domain_socket()
-                    .map_or(String::new(), |uds| format!("?socket={}", uds));
+        match self.database.as_ref() {
+            Some(database) => Ok(format!(
+                "mysql://{user}:{password}@{host}:{port}/{database}{unix_domain_socket}",
+                user = self.user,
+                password = password,
+                host = self.host,
+                port = self.port,
+                database = database,
+                unix_domain_socket = self.get_and_validate_unix_domain_socket()
+            )),
+            None => Ok(format!(
+                "mysql://{user}:{password}@{host}:{port}{unix_domain_socket}",
+                user = self.user,
+                password = password,
+                host = self.host,
+                port = self.port,
+                unix_domain_socket = self.get_and_validate_unix_domain_socket()
+            )),
+        }
+    }
 
-                match self.database.as_ref() {
-                    Some(database) => Ok(format!(
-                        "mysql://{user}:{password}@{host}:{port}/{database}{unix_domain_socket}",
-                        user = user,
-                        password = password,
-                        host = host,
-                        port = port,
-                        database = database,
-                        unix_domain_socket = unix_domain_socket
-                    )),
-                    None => Ok(format!(
-                        "mysql://{user}:{password}@{host}:{port}{unix_domain_socket}",
-                        user = user,
-                        password = password,
-                        host = host,
-                        port = port,
-                        unix_domain_socket = unix_domain_socket
-                    )),
-                }
+    fn get_and_validate_unix_domain_socket(&self) -> String {
+        valid_unix_domain_socket(self.unix_domain_socket.clone())
+            .map_or(String::new(), |uds| format!("?socket={}", uds))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PostgresConnection {
+    name: Option<String>,
+    user: String,
+    password: Option<String>,
+    host: String,
+    port: u64,
+    pub database: Option<String>,
+    unix_domain_socket: Option<PathBuf>,
+    pub limit_size: usize,
+    pub timeout_second: u64,
+}
+
+impl PostgresConnection {
+    pub fn database_url(&self) -> anyhow::Result<String> {
+        let password = self
+            .password
+            .as_ref()
+            .map_or(String::new(), |p| p.to_string());
+        self.build_database_url(password)
+    }
+
+    pub fn database_url_with_masked_password(&self) -> anyhow::Result<String> {
+        let password = self
+            .password
+            .as_ref()
+            .map_or(String::new(), |p| p.to_string());
+
+        let masked_password = "*".repeat(password.len());
+        self.build_database_url(masked_password)
+    }
+
+    fn build_database_url(&self, password: String) -> anyhow::Result<String> {
+        if let Some(unix_domain_socket) = self.get_and_validate_unix_domain_socket() {
+            match self.database.as_ref() {
+                Some(database) => Ok(format!(
+                    "postgres://?dbname={database}&host={unix_domain_socket}&user={user}&password={password}",
+                    database = database,
+                    unix_domain_socket = unix_domain_socket,
+                    user = self.user,
+                    password = password,
+                )),
+                None => Ok(format!(
+                    "postgres://?host={unix_domain_socket}&user={user}&password={password}",
+                    unix_domain_socket = unix_domain_socket,
+                    user = self.user,
+                    password = password,
+                )),
             }
-            DatabaseType::Postgres => {
-                let user = self.user.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type postgres needs the user field in Connection::build_database_url"
-                    )
-                })?;
-                let host = self.host.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type postgres needs the host field in Connection::build_database_url"
-                    )
-                })?;
-                let port = self.port.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "type postgres needs the port field in Connection::build_database_url"
-                    )
-                })?;
-
-                if let Some(unix_domain_socket) = self.valid_unix_domain_socket() {
-                    match self.database.as_ref() {
-                        Some(database) => Ok(format!(
-                            "postgres://?dbname={database}&host={unix_domain_socket}&user={user}&password={password}",
-                            database = database,
-                            unix_domain_socket = unix_domain_socket,
-                            user = user,
-                            password = password,
-                        )),
-                        None => Ok(format!(
-                            "postgres://?host={unix_domain_socket}&user={user}&password={password}",
-                            unix_domain_socket = unix_domain_socket,
-                            user = user,
-                            password = password,
-                        )),
-                    }
-                } else {
-                    match self.database.as_ref() {
-                        Some(database) => Ok(format!(
-                            "postgres://{user}:{password}@{host}:{port}/{database}",
-                            user = user,
-                            password = password,
-                            host = host,
-                            port = port,
-                            database = database,
-                        )),
-                        None => Ok(format!(
-                            "postgres://{user}:{password}@{host}:{port}",
-                            user = user,
-                            password = password,
-                            host = host,
-                            port = port,
-                        )),
-                    }
-                }
-            }
-            DatabaseType::Sqlite => {
-                let path = self.path.as_ref().map_or(
-                    Err(anyhow::anyhow!(
-                        "type sqlite needs the path field in Connection::build_database_url"
-                    )),
-                    |path| {
-                        expand_path(path).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "cannot expand file path in Connection::build_database_url"
-                            )
-                        })
-                    },
-                )?;
-
-                Ok(format!("sqlite://{path}", path = path.to_str().unwrap()))
+        } else {
+            match self.database.as_ref() {
+                Some(database) => Ok(format!(
+                    "postgres://{user}:{password}@{host}:{port}/{database}",
+                    user = self.user,
+                    password = password,
+                    host = self.host,
+                    port = self.port,
+                    database = database,
+                )),
+                None => Ok(format!(
+                    "postgres://{user}:{password}@{host}:{port}",
+                    user = self.user,
+                    password = password,
+                    host = self.host,
+                    port = self.port,
+                )),
             }
         }
     }
 
-    pub fn database_url_with_name(&self) -> anyhow::Result<String> {
-        match self.masked_database_url() {
-            Ok(url) => Ok(match &self.name {
-                Some(name) => format!("[{name}] {database_url}", name = name, database_url = url),
-                None => url,
-            }),
-            Err(e) => Err(anyhow::anyhow!(e)
-                .context("Failed to masked_database_url in Connection::database_url_with_name")),
-        }
+    fn get_and_validate_unix_domain_socket(&self) -> Option<String> {
+        valid_unix_domain_socket(self.unix_domain_socket.clone())
     }
+}
 
-    pub fn is_mysql(&self) -> bool {
-        matches!(self.r#type, DatabaseType::MySql)
+#[derive(Debug, Clone)]
+pub struct SqliteConnection {
+    name: Option<String>,
+    path: PathBuf,
+    pub limit_size: usize,
+    pub timeout_second: u64,
+}
+
+impl SqliteConnection {
+    fn database_url(&self) -> anyhow::Result<String> {
+        let path = expand_path(&self.path).ok_or_else(|| {
+            anyhow::anyhow!("cannot expand file path in SqliteConnection:: build_database_url")
+        })?;
+
+        Ok(format!("sqlite://{path}", path = path.to_str().unwrap()))
     }
+}
 
-    pub fn is_postgres(&self) -> bool {
-        matches!(self.r#type, DatabaseType::Postgres)
+fn valid_unix_domain_socket(unix_domain_socket: Option<PathBuf>) -> Option<String> {
+    if cfg!(windows) {
+        // NOTE:
+        // windows also supports UDS, but `rust` does not support UDS in windows now.
+        // https://github.com/rust-lang/rust/issues/56533
+        return None;
     }
-
-    fn valid_unix_domain_socket(&self) -> Option<String> {
-        if cfg!(windows) {
-            // NOTE:
-            // windows also supports UDS, but `rust` does not support UDS in windows now.
-            // https://github.com/rust-lang/rust/issues/56533
+    unix_domain_socket.as_ref().and_then(|uds| {
+        let path = expand_path(uds)?;
+        let path_str = path.to_str()?;
+        if path_str.is_empty() {
             return None;
         }
-        return self.unix_domain_socket.as_ref().and_then(|uds| {
-            let path = expand_path(uds)?;
-            let path_str = path.to_str()?;
-            if path_str.is_empty() {
-                return None;
-            }
-            Some(path_str.to_owned())
-        });
-    }
+        Some(path_str.to_owned())
+    })
 }
 
 impl Default for Connection {
     fn default() -> Self {
-        Self {
-            r#type: DatabaseType::MySql,
+        Connection::MySql(MySqlConnection {
             name: None,
-            user: Some("root".to_string()),
-            host: Some("localhost".to_string()),
-            port: Some(3306),
-            path: None,
+            user: "root".to_string(),
+            host: "localhost".to_string(),
+            port: 3306,
             password: None,
             database: None,
             unix_domain_socket: None,
             limit_size: default_limit_size(),
             timeout_second: default_timeout_second(),
-        }
+        })
     }
 }
 
-fn default_limit_size() -> usize {
+pub fn default_limit_size() -> usize {
     200
 }
 
@@ -261,211 +360,247 @@ fn expand_path(path: &Path) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod test {
-    use super::{expand_path, Connection, DatabaseType, Path, PathBuf};
+    use super::*;
     use std::env;
 
     #[test]
-    #[cfg(unix)]
-    fn test_database_url() {
-        let mysql_conn = Connection {
-            r#type: DatabaseType::MySql,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
+    fn test_default() {
+        let conn = Connection::default();
+        match conn {
+            Connection::MySql(mysql) => {
+                assert_eq!(mysql.user, "root");
+                assert_eq!(mysql.host, "localhost");
+                assert_eq!(mysql.port, 3306);
+                assert_eq!(mysql.limit_size, 200);
+                assert_eq!(mysql.timeout_second, 5);
+            }
+            _ => panic!("Default should be MySql"),
+        }
+    }
+    mod mysql_connection_tests {
+        use super::*;
 
-        let mysql_result = mysql_conn.database_url().unwrap();
-        assert_eq!(
-            mysql_result,
-            "mysql://root:password@localhost:3306/city".to_owned()
-        );
+        #[test]
+        fn database_url() {
+            let mysql_conn = Connection::MySql(MySqlConnection {
+                name: None,
+                user: "root".to_owned(),
+                host: "localhost".to_owned(),
+                port: 3306,
+                password: Some("password".to_owned()),
+                database: Some("city".to_owned()),
+                unix_domain_socket: None,
+                limit_size: 200,
+                timeout_second: 5,
+            });
 
-        let postgres_conn = Connection {
-            r#type: DatabaseType::Postgres,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
+            let mysql_result = mysql_conn.database_url().unwrap();
+            assert_eq!(
+                mysql_result,
+                "mysql://root:password@localhost:3306/city".to_owned()
+            );
+        }
 
-        let postgres_result = postgres_conn.database_url().unwrap();
-        assert_eq!(
-            postgres_result,
-            "postgres://root:password@localhost:3306/city".to_owned()
-        );
+        #[test]
+        fn database_url_with_name() {
+            let mysql_conn = Connection::MySql(MySqlConnection {
+                name: Some("my_mysql_connection".to_owned()),
+                user: "root".to_owned(),
+                host: "localhost".to_owned(),
+                port: 3306,
+                password: Some("password".to_owned()),
+                database: Some("city".to_owned()),
+                unix_domain_socket: None,
+                limit_size: 200,
+                timeout_second: 5,
+            });
 
-        let sqlite_conn = Connection {
-            r#type: DatabaseType::Sqlite,
-            name: None,
-            user: None,
-            host: None,
-            port: None,
-            path: Some(PathBuf::from("/home/user/sqlite3.db")),
-            password: None,
-            database: None,
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
+            let mysql_result = mysql_conn.database_url_with_name().unwrap();
+            assert_eq!(
+                mysql_result,
+                "[my_mysql_connection] mysql://root:********@localhost:3306/city".to_owned()
+            );
+        }
 
-        let sqlite_result = sqlite_conn.database_url().unwrap();
-        assert_eq!(sqlite_result, "sqlite:///home/user/sqlite3.db".to_owned());
+        #[test]
+        #[cfg(unix)]
+        fn database_url_in_unix_includes_socket() {
+            let mysql_conn = Connection::MySql(MySqlConnection {
+                name: None,
+                user: "root".to_owned(),
+                host: "localhost".to_owned(),
+                port: 3306,
+                password: Some("password".to_owned()),
+                database: Some("city".to_owned()),
+                unix_domain_socket: Some(Path::new("/tmp/mysql.sock").to_path_buf()),
+                limit_size: 200,
+                timeout_second: 5,
+            });
+
+            assert_eq!(
+                mysql_conn.database_url().unwrap(),
+                "mysql://root:password@localhost:3306/city?socket=/tmp/mysql.sock".to_owned()
+            );
+        }
+
+        #[test]
+        #[cfg(windows)]
+        fn database_url_in_windows_ignores_socket() {
+            let mysql_conn = Connection::MySql(MySqlConnection {
+                name: None,
+                user: "root".to_owned(),
+                host: "localhost".to_owned(),
+                port: 3306,
+                password: Some("password".to_owned()),
+                database: Some("city".to_owned()),
+                unix_domain_socket: "/tmp/mysql.sock".to_owned(),
+                limit_size: 200,
+                timeout_second: 5,
+            });
+
+            assert_eq!(
+                mysql_conn.database_url().unwrap(),
+                "mysql://root:password@localhost:3306/city".to_owned()
+            );
+        }
     }
 
-    #[test]
-    #[cfg(unix)]
-    fn test_dataset_url_in_unix() {
-        let mut mysql_conn = Connection {
-            r#type: DatabaseType::MySql,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
+    mod postgres_connection_tests {
+        use super::*;
 
-        assert_eq!(
-            mysql_conn.database_url().unwrap(),
-            "mysql://root:password@localhost:3306/city".to_owned()
-        );
+        #[test]
+        fn database_url() {
+            let postgres_conn = Connection::Postgres(PostgresConnection {
+                name: None,
+                user: "root".to_owned(),
+                host: "localhost".to_owned(),
+                port: 3306,
+                password: Some("password".to_owned()),
+                database: Some("city".to_owned()),
+                unix_domain_socket: None,
+                limit_size: 200,
+                timeout_second: 5,
+            });
 
-        mysql_conn.unix_domain_socket = Some(Path::new("/tmp/mysql.sock").to_path_buf());
-        assert_eq!(
-            mysql_conn.database_url().unwrap(),
-            "mysql://root:password@localhost:3306/city?socket=/tmp/mysql.sock".to_owned()
-        );
+            let postgres_result = postgres_conn.database_url().unwrap();
+            assert_eq!(
+                postgres_result,
+                "postgres://root:password@localhost:3306/city".to_owned()
+            );
+        }
 
-        let mut postgres_conn = Connection {
-            r#type: DatabaseType::Postgres,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
+        #[test]
+        fn database_url_with_name() {
+            let postgres_conn = Connection::Postgres(PostgresConnection {
+                name: Some("my_postgres_connection".to_owned()),
+                user: "root".to_owned(),
+                host: "localhost".to_owned(),
+                port: 3306,
+                password: Some("password".to_owned()),
+                database: Some("city".to_owned()),
+                unix_domain_socket: None,
+                limit_size: 200,
+                timeout_second: 5,
+            });
 
-        assert_eq!(
-            postgres_conn.database_url().unwrap(),
-            "postgres://root:password@localhost:3306/city".to_owned()
-        );
-        postgres_conn.unix_domain_socket = Some(Path::new("/tmp").to_path_buf());
-        assert_eq!(
-            postgres_conn.database_url().unwrap(),
-            "postgres://?dbname=city&host=/tmp&user=root&password=password".to_owned()
-        );
+            let postgres_result = postgres_conn.database_url_with_name().unwrap();
+            assert_eq!(
+                postgres_result,
+                "[my_postgres_connection] postgres://root:********@localhost:3306/city".to_owned()
+            );
+        }
 
-        let sqlite_conn = Connection {
-            r#type: DatabaseType::Sqlite,
-            name: None,
-            user: None,
-            host: None,
-            port: None,
-            path: Some(PathBuf::from("/home/user/sqlite3.db")),
-            password: None,
-            database: None,
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
+        #[test]
+        #[cfg(unix)]
+        fn database_url_in_unix_includes_socket() {
+            let postgres_conn = Connection::Postgres(PostgresConnection {
+                name: None,
+                user: "root".to_owned(),
+                host: "localhost".to_owned(),
+                port: 3306,
+                password: Some("password".to_owned()),
+                database: Some("city".to_owned()),
+                unix_domain_socket: Some(Path::new("/tmp").to_path_buf()),
+                limit_size: 200,
+                timeout_second: 5,
+            });
 
-        let sqlite_result = sqlite_conn.database_url().unwrap();
-        assert_eq!(sqlite_result, "sqlite:///home/user/sqlite3.db".to_owned());
+            assert_eq!(
+                postgres_conn.database_url().unwrap(),
+                "postgres://?dbname=city&host=/tmp&user=root&password=password".to_owned()
+            );
+        }
+
+        #[test]
+        #[cfg(windows)]
+        fn database_url_in_windows_ignores_socket() {
+            let postgres_conn = Connection::Postgres(PostgresConnection {
+                name: None,
+                user: "root".to_owned(),
+                host: "localhost".to_owned(),
+                port: 3306,
+                password: Some("password".to_owned()),
+                database: Some("city".to_owned()),
+                unix_domain_socket: Some("/tmp".to_owned()),
+                limit_size: 200,
+                timeout_second: 5,
+            });
+
+            assert_eq!(
+                postgres_conn.database_url().unwrap(),
+                "postgres://root:password@localhost:3306/city".to_owned()
+            );
+        }
     }
 
-    #[test]
-    #[cfg(windows)]
-    fn test_database_url_in_windows() {
-        let mut mysql_conn = Connection {
-            r#type: DatabaseType::MySql,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
+    mod sqlite_connection_tests {
+        use super::*;
 
-        assert_eq!(
-            mysql_conn.database_url().unwrap(),
-            "mysql://root:password@localhost:3306/city".to_owned()
-        );
+        #[test]
+        fn database_url() {
+            let sqlite_conn = Connection::Sqlite(SqliteConnection {
+                name: None,
+                path: PathBuf::from("/home/user/sqlite3.db"),
+                limit_size: 200,
+                timeout_second: 5,
+            });
 
-        mysql_conn.unix_domain_socket = Some(Path::new("/tmp/mysql.sock").to_path_buf());
-        assert_eq!(
-            mysql_conn.database_url().unwrap(),
-            "mysql://root:password@localhost:3306/city".to_owned()
-        );
+            let sqlite_result = sqlite_conn.database_url().unwrap();
+            assert_eq!(sqlite_result, "sqlite:///home/user/sqlite3.db".to_owned());
+        }
 
-        let mut postgres_conn = Connection {
-            r#type: DatabaseType::Postgres,
-            name: None,
-            user: Some("root".to_owned()),
-            host: Some("localhost".to_owned()),
-            port: Some(3306),
-            path: None,
-            password: Some("password".to_owned()),
-            database: Some("city".to_owned()),
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
+        #[test]
+        fn database_url_with_name() {
+            let sqlite_conn = Connection::Sqlite(SqliteConnection {
+                name: Some("my_sqlite_connection".to_owned()),
+                path: PathBuf::from("/home/user/sqlite3.db"),
+                limit_size: 200,
+                timeout_second: 5,
+            });
 
-        assert_eq!(
-            postgres_conn.database_url().unwrap(),
-            "postgres://root:password@localhost:3306/city".to_owned()
-        );
-        postgres_conn.unix_domain_socket = Some(Path::new("/tmp").to_path_buf());
-        assert_eq!(
-            postgres_conn.database_url().unwrap(),
-            "postgres://root:password@localhost:3306/city".to_owned()
-        );
+            let sqlite_result = sqlite_conn.database_url_with_name().unwrap();
+            assert_eq!(
+                sqlite_result,
+                "[my_sqlite_connection] sqlite:///home/user/sqlite3.db".to_owned()
+            );
+        }
 
-        let sqlite_conn = Connection {
-            r#type: DatabaseType::Sqlite,
-            name: None,
-            user: None,
-            host: None,
-            port: None,
-            path: Some(PathBuf::from("/home/user/sqlite3.db")),
-            password: None,
-            database: None,
-            unix_domain_socket: None,
-            limit_size: 200,
-            timeout_second: 5,
-        };
+        #[test]
+        #[cfg(windows)]
+        fn database_url_in_windows() {
+            let sqlite_conn = Connection::Sqlite(SqliteConnection {
+                name: None,
+                path: PathBuf::from("/home/user/sqlite3.db"),
+                limit_size: 200,
+                timeout_second: 5,
+            });
 
-        let sqlite_result = sqlite_conn.database_url().unwrap();
-        assert_eq!(
-            sqlite_result,
-            "sqlite://\\home\\user\\sqlite3.db".to_owned()
-        );
+            let sqlite_result = sqlite_conn.database_url().unwrap();
+            assert_eq!(
+                sqlite_result,
+                "sqlite://\\home\\user\\sqlite3.db".to_owned()
+            );
+        }
     }
 
     #[test]
@@ -476,29 +611,29 @@ mod test {
         env::set_var("TEST", test_env);
 
         assert_eq!(
-            expand_path(&Path::new("$HOME/foo")),
+            expand_path(Path::new("$HOME/foo")),
             Some(PathBuf::from(&home).join("foo"))
         );
 
         assert_eq!(
-            expand_path(&Path::new("$HOME/foo/$TEST/bar")),
+            expand_path(Path::new("$HOME/foo/$TEST/bar")),
             Some(PathBuf::from(&home).join("foo").join(test_env).join("bar"))
         );
 
         assert_eq!(
-            expand_path(&Path::new("~/foo")),
+            expand_path(Path::new("~/foo")),
             Some(PathBuf::from(&home).join("foo"))
         );
 
         assert_eq!(
-            expand_path(&Path::new("~/foo/~/bar")),
+            expand_path(Path::new("~/foo/~/bar")),
             Some(PathBuf::from(&home).join("foo").join("~").join("bar"))
         );
     }
 
     #[test]
     #[cfg(windows)]
-    fn test_expand_patha() {
+    fn test_expand_path() {
         let home = std::env::var("HOMEPATH").unwrap();
         let test_env = "baz";
         env::set_var("TEST", test_env);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,531 @@
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone)]
+enum DatabaseType {
+    #[serde(rename = "mysql")]
+    MySql,
+    #[serde(rename = "postgres")]
+    Postgres,
+    #[serde(rename = "sqlite")]
+    Sqlite,
+}
+
+impl fmt::Display for DatabaseType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::MySql => write!(f, "mysql"),
+            Self::Postgres => write!(f, "postgres"),
+            Self::Sqlite => write!(f, "sqlite"),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Connection {
+    r#type: DatabaseType,
+    name: Option<String>,
+    user: Option<String>,
+    host: Option<String>,
+    port: Option<u64>,
+    path: Option<std::path::PathBuf>,
+    password: Option<String>,
+    unix_domain_socket: Option<std::path::PathBuf>,
+    pub database: Option<String>,
+    #[serde(default = "default_limit_size")]
+    pub limit_size: usize,
+    #[serde(default = "default_timeout_second")]
+    pub timeout_second: u64,
+}
+
+impl Connection {
+    pub fn database_url(&self) -> anyhow::Result<String> {
+        let password = self
+            .password
+            .as_ref()
+            .map_or(String::new(), |p| p.to_string());
+        self.build_database_url(password)
+    }
+
+    fn masked_database_url(&self) -> anyhow::Result<String> {
+        let password = self
+            .password
+            .as_ref()
+            .map_or(String::new(), |p| p.to_string());
+
+        let masked_password = "*".repeat(password.len());
+        self.build_database_url(masked_password)
+    }
+
+    fn build_database_url(&self, password: String) -> anyhow::Result<String> {
+        match self.r#type {
+            DatabaseType::MySql => {
+                let user = self.user.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "type mysql needs the user field in Connection::build_database_url"
+                    )
+                })?;
+                let host = self.host.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "type mysql needs the host field in Connection::build_database_url"
+                    )
+                })?;
+                let port = self.port.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "type mysql needs the port field in Connection::build_database_url"
+                    )
+                })?;
+                let unix_domain_socket = self
+                    .valid_unix_domain_socket()
+                    .map_or(String::new(), |uds| format!("?socket={}", uds));
+
+                match self.database.as_ref() {
+                    Some(database) => Ok(format!(
+                        "mysql://{user}:{password}@{host}:{port}/{database}{unix_domain_socket}",
+                        user = user,
+                        password = password,
+                        host = host,
+                        port = port,
+                        database = database,
+                        unix_domain_socket = unix_domain_socket
+                    )),
+                    None => Ok(format!(
+                        "mysql://{user}:{password}@{host}:{port}{unix_domain_socket}",
+                        user = user,
+                        password = password,
+                        host = host,
+                        port = port,
+                        unix_domain_socket = unix_domain_socket
+                    )),
+                }
+            }
+            DatabaseType::Postgres => {
+                let user = self.user.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "type postgres needs the user field in Connection::build_database_url"
+                    )
+                })?;
+                let host = self.host.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "type postgres needs the host field in Connection::build_database_url"
+                    )
+                })?;
+                let port = self.port.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "type postgres needs the port field in Connection::build_database_url"
+                    )
+                })?;
+
+                if let Some(unix_domain_socket) = self.valid_unix_domain_socket() {
+                    match self.database.as_ref() {
+                        Some(database) => Ok(format!(
+                            "postgres://?dbname={database}&host={unix_domain_socket}&user={user}&password={password}",
+                            database = database,
+                            unix_domain_socket = unix_domain_socket,
+                            user = user,
+                            password = password,
+                        )),
+                        None => Ok(format!(
+                            "postgres://?host={unix_domain_socket}&user={user}&password={password}",
+                            unix_domain_socket = unix_domain_socket,
+                            user = user,
+                            password = password,
+                        )),
+                    }
+                } else {
+                    match self.database.as_ref() {
+                        Some(database) => Ok(format!(
+                            "postgres://{user}:{password}@{host}:{port}/{database}",
+                            user = user,
+                            password = password,
+                            host = host,
+                            port = port,
+                            database = database,
+                        )),
+                        None => Ok(format!(
+                            "postgres://{user}:{password}@{host}:{port}",
+                            user = user,
+                            password = password,
+                            host = host,
+                            port = port,
+                        )),
+                    }
+                }
+            }
+            DatabaseType::Sqlite => {
+                let path = self.path.as_ref().map_or(
+                    Err(anyhow::anyhow!(
+                        "type sqlite needs the path field in Connection::build_database_url"
+                    )),
+                    |path| {
+                        expand_path(path).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "cannot expand file path in Connection::build_database_url"
+                            )
+                        })
+                    },
+                )?;
+
+                Ok(format!("sqlite://{path}", path = path.to_str().unwrap()))
+            }
+        }
+    }
+
+    pub fn database_url_with_name(&self) -> anyhow::Result<String> {
+        match self.masked_database_url() {
+            Ok(url) => Ok(match &self.name {
+                Some(name) => format!("[{name}] {database_url}", name = name, database_url = url),
+                None => url,
+            }),
+            Err(e) => Err(anyhow::anyhow!(e)
+                .context("Failed to masked_database_url in Connection::database_url_with_name")),
+        }
+    }
+
+    pub fn is_mysql(&self) -> bool {
+        matches!(self.r#type, DatabaseType::MySql)
+    }
+
+    pub fn is_postgres(&self) -> bool {
+        matches!(self.r#type, DatabaseType::Postgres)
+    }
+
+    fn valid_unix_domain_socket(&self) -> Option<String> {
+        if cfg!(windows) {
+            // NOTE:
+            // windows also supports UDS, but `rust` does not support UDS in windows now.
+            // https://github.com/rust-lang/rust/issues/56533
+            return None;
+        }
+        return self.unix_domain_socket.as_ref().and_then(|uds| {
+            let path = expand_path(uds)?;
+            let path_str = path.to_str()?;
+            if path_str.is_empty() {
+                return None;
+            }
+            Some(path_str.to_owned())
+        });
+    }
+}
+
+impl Default for Connection {
+    fn default() -> Self {
+        Self {
+            r#type: DatabaseType::MySql,
+            name: None,
+            user: Some("root".to_string()),
+            host: Some("localhost".to_string()),
+            port: Some(3306),
+            path: None,
+            password: None,
+            database: None,
+            unix_domain_socket: None,
+            limit_size: default_limit_size(),
+            timeout_second: default_timeout_second(),
+        }
+    }
+}
+
+fn default_limit_size() -> usize {
+    200
+}
+
+fn default_timeout_second() -> u64 {
+    5
+}
+
+fn expand_path(path: &Path) -> Option<PathBuf> {
+    let mut expanded_path = PathBuf::new();
+    let mut path_iter = path.iter();
+    if path.starts_with("~") {
+        path_iter.next()?;
+        expanded_path = expanded_path.join(dirs_next::home_dir()?);
+    }
+    for path in path_iter {
+        let path = path.to_str()?;
+        expanded_path = if cfg!(unix) && path.starts_with('$') {
+            expanded_path.join(std::env::var(path.strip_prefix('$')?).unwrap_or_default())
+        } else if cfg!(windows) && path.starts_with('%') && path.ends_with('%') {
+            expanded_path
+                .join(std::env::var(path.strip_prefix('%')?.strip_suffix('%')?).unwrap_or_default())
+        } else {
+            expanded_path.join(path)
+        }
+    }
+    Some(expanded_path)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{expand_path, Connection, DatabaseType, Path, PathBuf};
+    use std::env;
+
+    #[test]
+    #[cfg(unix)]
+    fn test_database_url() {
+        let mysql_conn = Connection {
+            r#type: DatabaseType::MySql,
+            name: None,
+            user: Some("root".to_owned()),
+            host: Some("localhost".to_owned()),
+            port: Some(3306),
+            path: None,
+            password: Some("password".to_owned()),
+            database: Some("city".to_owned()),
+            unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
+        };
+
+        let mysql_result = mysql_conn.database_url().unwrap();
+        assert_eq!(
+            mysql_result,
+            "mysql://root:password@localhost:3306/city".to_owned()
+        );
+
+        let postgres_conn = Connection {
+            r#type: DatabaseType::Postgres,
+            name: None,
+            user: Some("root".to_owned()),
+            host: Some("localhost".to_owned()),
+            port: Some(3306),
+            path: None,
+            password: Some("password".to_owned()),
+            database: Some("city".to_owned()),
+            unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
+        };
+
+        let postgres_result = postgres_conn.database_url().unwrap();
+        assert_eq!(
+            postgres_result,
+            "postgres://root:password@localhost:3306/city".to_owned()
+        );
+
+        let sqlite_conn = Connection {
+            r#type: DatabaseType::Sqlite,
+            name: None,
+            user: None,
+            host: None,
+            port: None,
+            path: Some(PathBuf::from("/home/user/sqlite3.db")),
+            password: None,
+            database: None,
+            unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
+        };
+
+        let sqlite_result = sqlite_conn.database_url().unwrap();
+        assert_eq!(sqlite_result, "sqlite:///home/user/sqlite3.db".to_owned());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_dataset_url_in_unix() {
+        let mut mysql_conn = Connection {
+            r#type: DatabaseType::MySql,
+            name: None,
+            user: Some("root".to_owned()),
+            host: Some("localhost".to_owned()),
+            port: Some(3306),
+            path: None,
+            password: Some("password".to_owned()),
+            database: Some("city".to_owned()),
+            unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
+        };
+
+        assert_eq!(
+            mysql_conn.database_url().unwrap(),
+            "mysql://root:password@localhost:3306/city".to_owned()
+        );
+
+        mysql_conn.unix_domain_socket = Some(Path::new("/tmp/mysql.sock").to_path_buf());
+        assert_eq!(
+            mysql_conn.database_url().unwrap(),
+            "mysql://root:password@localhost:3306/city?socket=/tmp/mysql.sock".to_owned()
+        );
+
+        let mut postgres_conn = Connection {
+            r#type: DatabaseType::Postgres,
+            name: None,
+            user: Some("root".to_owned()),
+            host: Some("localhost".to_owned()),
+            port: Some(3306),
+            path: None,
+            password: Some("password".to_owned()),
+            database: Some("city".to_owned()),
+            unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
+        };
+
+        assert_eq!(
+            postgres_conn.database_url().unwrap(),
+            "postgres://root:password@localhost:3306/city".to_owned()
+        );
+        postgres_conn.unix_domain_socket = Some(Path::new("/tmp").to_path_buf());
+        assert_eq!(
+            postgres_conn.database_url().unwrap(),
+            "postgres://?dbname=city&host=/tmp&user=root&password=password".to_owned()
+        );
+
+        let sqlite_conn = Connection {
+            r#type: DatabaseType::Sqlite,
+            name: None,
+            user: None,
+            host: None,
+            port: None,
+            path: Some(PathBuf::from("/home/user/sqlite3.db")),
+            password: None,
+            database: None,
+            unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
+        };
+
+        let sqlite_result = sqlite_conn.database_url().unwrap();
+        assert_eq!(sqlite_result, "sqlite:///home/user/sqlite3.db".to_owned());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_database_url_in_windows() {
+        let mut mysql_conn = Connection {
+            r#type: DatabaseType::MySql,
+            name: None,
+            user: Some("root".to_owned()),
+            host: Some("localhost".to_owned()),
+            port: Some(3306),
+            path: None,
+            password: Some("password".to_owned()),
+            database: Some("city".to_owned()),
+            unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
+        };
+
+        assert_eq!(
+            mysql_conn.database_url().unwrap(),
+            "mysql://root:password@localhost:3306/city".to_owned()
+        );
+
+        mysql_conn.unix_domain_socket = Some(Path::new("/tmp/mysql.sock").to_path_buf());
+        assert_eq!(
+            mysql_conn.database_url().unwrap(),
+            "mysql://root:password@localhost:3306/city".to_owned()
+        );
+
+        let mut postgres_conn = Connection {
+            r#type: DatabaseType::Postgres,
+            name: None,
+            user: Some("root".to_owned()),
+            host: Some("localhost".to_owned()),
+            port: Some(3306),
+            path: None,
+            password: Some("password".to_owned()),
+            database: Some("city".to_owned()),
+            unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
+        };
+
+        assert_eq!(
+            postgres_conn.database_url().unwrap(),
+            "postgres://root:password@localhost:3306/city".to_owned()
+        );
+        postgres_conn.unix_domain_socket = Some(Path::new("/tmp").to_path_buf());
+        assert_eq!(
+            postgres_conn.database_url().unwrap(),
+            "postgres://root:password@localhost:3306/city".to_owned()
+        );
+
+        let sqlite_conn = Connection {
+            r#type: DatabaseType::Sqlite,
+            name: None,
+            user: None,
+            host: None,
+            port: None,
+            path: Some(PathBuf::from("/home/user/sqlite3.db")),
+            password: None,
+            database: None,
+            unix_domain_socket: None,
+            limit_size: 200,
+            timeout_second: 5,
+        };
+
+        let sqlite_result = sqlite_conn.database_url().unwrap();
+        assert_eq!(
+            sqlite_result,
+            "sqlite://\\home\\user\\sqlite3.db".to_owned()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_expand_path() {
+        let home = env::var("HOME").unwrap();
+        let test_env = "baz";
+        env::set_var("TEST", test_env);
+
+        assert_eq!(
+            expand_path(&Path::new("$HOME/foo")),
+            Some(PathBuf::from(&home).join("foo"))
+        );
+
+        assert_eq!(
+            expand_path(&Path::new("$HOME/foo/$TEST/bar")),
+            Some(PathBuf::from(&home).join("foo").join(test_env).join("bar"))
+        );
+
+        assert_eq!(
+            expand_path(&Path::new("~/foo")),
+            Some(PathBuf::from(&home).join("foo"))
+        );
+
+        assert_eq!(
+            expand_path(&Path::new("~/foo/~/bar")),
+            Some(PathBuf::from(&home).join("foo").join("~").join("bar"))
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_expand_patha() {
+        let home = std::env::var("HOMEPATH").unwrap();
+        let test_env = "baz";
+        env::set_var("TEST", test_env);
+
+        assert_eq!(
+            expand_path(&Path::new("%HOMEPATH%/foo")),
+            Some(PathBuf::from(&home).join("foo"))
+        );
+
+        assert_eq!(
+            expand_path(&Path::new("%HOMEPATH%/foo/%TEST%/bar")),
+            Some(PathBuf::from(&home).join("foo").join(test_env).join("bar"))
+        );
+
+        assert_eq!(
+            expand_path(&Path::new("~/foo")),
+            Some(PathBuf::from(&dirs_next::home_dir().unwrap()).join("foo"))
+        );
+
+        assert_eq!(
+            expand_path(&Path::new("~/foo/~/bar")),
+            Some(
+                PathBuf::from(&dirs_next::home_dir().unwrap())
+                    .join("foo")
+                    .join("~")
+                    .join("bar")
+            )
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod clipboard;
 mod components;
 mod config;
+mod connection;
 mod database;
 mod event;
 mod key_bind;


### PR DESCRIPTION
Here's a checklist for things that will be checked during review or continuous integration.

- [x] Added passing unit tests
- [x] `cargo test` passes locally. It takes much time.
- [x] Run `cargo fmt`
 
---

Hi! I am looking into adding Mssql support for Zhobo. Since I'll be adding another connection, I thought it would be nice to leverage the type system to make invalid state impossible. This meant turning `Connection` into an enum and having associated structs on each option.

This change:
1. Pulls `Connection` and `DatabaseType` into a new file, connection.rs
2. Creates a `ReadConnection` for reading all options from the config file
3. Creates `Connection.from(read_connection: ReadConnection) -> Self` along with some other helper methods.
4. Creates `MySqlConnection`, `PostgresConnection`, and `SqliteConnection`. They each implement the needed methods.
5. Organizes tests by connection type
6. Adjusts calling code.

A couple of annoyances will result from this:
1. Each new property on a `Connection` has to be added separately to the `ReadConnection`.
2. Adding methods to `Connection` will be a little harder. Calling code will need to match the variants, unless a helper method is added.

I figured these were acceptable considering the advantages, but curious on your thoughts as well.

I have tested all connection types with test databases on mac. **This hasn't been tested on windows or linux yet.**
